### PR TITLE
delete semantic

### DIFF
--- a/src/features/semantics/SemanticDeleteAsk.js
+++ b/src/features/semantics/SemanticDeleteAsk.js
@@ -22,7 +22,7 @@ export default function SemanticDeleteAsk(){
         // const data = {"session_id": session_id, "organisation_id": organisation_id, "knowledge_base_id": knowledgeBase_id };
         console.log("delete data",semantic)
 
-        dispatch(deleteSemantic({session_id:session_id, organisation_id: organisation_id, knowledge_base_id: knowledgeBase_id, word: semantic.word}))
+        dispatch(deleteSemantic({session_id:session_id, organisation_id: organisation_id, knowledge_base_id: knowledgeBase_id, word: semantic.word, semantic: semantic.semantic}))
         dispatch(closeDeleteForm());
     }
 

--- a/src/features/semantics/semanticSlice.js
+++ b/src/features/semantics/semanticSlice.js
@@ -49,10 +49,10 @@ export const updateSemantics = createAsyncThunk(
 export const deleteSemantic = createAsyncThunk(
     "semantic/deleteSemantic",
 
-        async ({session_id, organisation_id, knowledge_base_id, word}) => {
+        async ({session_id, organisation_id, knowledge_base_id, word, semantic}) => {
 
             const api_base = window.ENV.api_base;
-            const url = api_base + `/language/delete-semantic/${encodeURIComponent(organisation_id)}/${encodeURIComponent(knowledge_base_id)}/${encodeURIComponent(word)}`
+            const url = api_base + `/language/delete-semantic/${encodeURIComponent(organisation_id)}/${encodeURIComponent(knowledge_base_id)}/${encodeURIComponent(word)}/${encodeURIComponent(semantic)}`
 
             return axios.delete(url, Comms.getHeaders(session_id))
                 .then( (response) => {


### PR DESCRIPTION
Deleting a semantic was no longer working due to the api now needing the semantic value to be passed too. 

- updated the slice to reflect this.
- updated SemanticDeleteAsk.js to pass the semantic value.