### PR TITLE
Cannot hit 'Enter' on Mind forms

### DIFF
--- a/src/features/categorization/CategorizationEdit.js
+++ b/src/features/categorization/CategorizationEdit.js
@@ -93,7 +93,7 @@ export function CategorizationEdit(){
                                                     placeholder=""
                                                     value={categoryLabel}
                                                     onChange={(event) => setCategoryLabel(event.target.value)}
-                                                    onKeyDown={(e) => {handleKeyDown(e)}}
+                                                   onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                             />
                                         </form>
                                     </span>
@@ -108,7 +108,7 @@ export function CategorizationEdit(){
                                                     title="SimSage advanced query language expression (e.g. (word(test))  )"
                                                     value={rule}
                                                     onChange={(event) => setRule(event.target.value)}
-                                                    onKeyDown={(e) => {handleKeyDown(e)}}
+                                                   onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                             />
                                         </form>
                                     </span>

--- a/src/features/semantics/SemanticEdit.js
+++ b/src/features/semantics/SemanticEdit.js
@@ -64,6 +64,7 @@ export function SemanticEdit(){
                                                    autoFocus={true}
                                                    autoComplete="false"
                                                    placeholder="e.g. Wellington"
+                                                   onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                                 // value={word}
                                                    {...register("word", {required: true})}
                                                 // onChange={(event) => setWord(event.target.value)}
@@ -80,6 +81,7 @@ export function SemanticEdit(){
                                                    autoFocus={true}
                                                    autoComplete="false"
                                                    placeholder="e.g. City"
+                                                   onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                                 // value={semantic}
                                                    {...register("semantic", {required: true})}
                                                 // onChange={(event) => semantic(event.target.value)}

--- a/src/features/synsets/SynsetEdit.js
+++ b/src/features/synsets/SynsetEdit.js
@@ -108,6 +108,7 @@ export default function SynsetEdit(){
                                                 placeholder="e.g. Law..."
                                                 value= {word}
                                                 onChange={(e) => setWord(e.target.value)}
+                                                onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                             />
                                         </form>
                                     </span>

--- a/src/features/text_to_search/TextToSearchEdit.js
+++ b/src/features/text_to_search/TextToSearchEdit.js
@@ -85,6 +85,7 @@ export function TextToSearchEdit(props){
                                                    title="SimSage advanced query language expression (e.g. (word(test))  )"
                                                 value= {searchPart}
                                                 onChange={(e) => setSearchPart(e.target.value)}
+                                                onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                             />
                                         </form>
                                     </span>
@@ -98,6 +99,7 @@ export function TextToSearchEdit(props){
                                                 placeholder="e.g. and"
                                                 value= {searchType}
                                                 onChange={(e) => setSearchType(e.target.value)}
+                                                onKeyDown={(e) => {if(e.key === 'Enter') e.preventDefault()}}
                                             />
                                         </form>
                                     </span>


### PR DESCRIPTION
This look to be a bug with React-hook-forms. hitting enter on input skips all validation you have added. as a work around I have added a prevent default if you hit enter to each input field. 