### PR TITLE
fix bot link redirect bug

### DIFF
--- a/src/features/bot/BotList.js
+++ b/src/features/bot/BotList.js
@@ -242,9 +242,10 @@ export default function BotList() {
                                         </td>
                                         <td className="pt-3 px-4 pb-3">
                                             { memory.urlList.map( url => {
+                                                const formatted_url = url.slice(0,8).includes("http") ? url : "https://"+url
                                                 return (
                                                     <div className="mind-text-column text-black-50 small text-truncate mb-1" style={{maxWidth: "250px"}}> 
-                                                        <a href={url} className="text-black-50" title={url}>{url}</a>
+                                                        <a href={formatted_url} target="_blank" className="text-black-50" title={url}>{url}</a>
                                                     </div>
                                                 )
                                             })


### PR DESCRIPTION
I have added in a line to add the https:// prefix if it is not already there. I also made the links open in another tab