### PR TITLE
stop synset filter clearing

### DIFF
--- a/src/features/synsets/SynsetList.js
+++ b/src/features/synsets/SynsetList.js
@@ -60,7 +60,7 @@ export default function SynsetList() {
         e.preventDefault()
         dispatch(loadSynsets(data));
         dispatch(noResultsMessage(true))
-        setSynSetFilter('');
+
     }
 
     const handleEdit = (synset) => {


### PR DESCRIPTION
Stopping the filter clearing when you hit enter. 