### PR TITLE
source table header when list empty

### DIFF
--- a/src/features/sources/SourceHome.js
+++ b/src/features/sources/SourceHome.js
@@ -340,7 +340,7 @@ export default function SourceHome(props) {
 
                 </div>
             </div>
-            {source_list_status !== undefined && source_list && source_list.length > 0 &&
+            {
                 <div className="source-page">
                     <table className="table">
                         <thead>


### PR DESCRIPTION
Adding in the table headers when the source list is empty